### PR TITLE
Fix for build on Linux

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -64,6 +64,10 @@
 #include <QUrlQuery>
 #endif
 
+#include <boost/bind/bind.hpp>
+#include <boost/signals2/signal.hpp>
+using namespace boost::placeholders;
+
 const std::string BitcoinGUI::DEFAULT_UIPLATFORM =
 #if defined(Q_OS_MAC)
         "macosx"

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -29,6 +29,10 @@
 #include <QDebug>
 #include <QTimer>
 
+#include <boost/bind/bind.hpp>
+#include <boost/signals2/signal.hpp>
+using namespace boost::placeholders;
+
 class CBlockIndex;
 
 static const int64_t nClientStartupTime = GetTime();

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -557,7 +557,8 @@ bool PaymentServer::processPaymentRequest(const PaymentRequestPlus& request, Sen
     QList<std::pair<CScript, CAmount> > sendingTos = request.getPayTo();
     QStringList addresses;
 
-    Q_FOREACH(const PAIRTYPE(CScript, CAmount)& sendingTo, sendingTos) {
+    //Q_FOREACH(const PAIRTYPE(CScript, CAmount)& sendingTo, sendingTos) {
+    for (const PAIRTYPE(CScript, CAmount)& sendingTo : sendingTos) {
         // Extract and check destination addresses
         CTxDestination dest;
         if (ExtractDestination(sendingTo.first, dest)) {

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -23,6 +23,10 @@
 #include <QDesktopWidget>
 #include <QPainter>
 
+#include <boost/bind/bind.hpp>
+#include <boost/signals2/signal.hpp>
+using namespace boost::placeholders;
+
 SplashScreen::SplashScreen(Qt::WindowFlags f, const NetworkStyle *networkStyle) :
     QWidget(0, f), curAlignment(0)
 {

--- a/src/qt/test/paymentservertests.cpp
+++ b/src/qt/test/paymentservertests.cpp
@@ -196,7 +196,8 @@ void PaymentServerTests::paymentServerTests()
     QVERIFY(r.paymentRequest.IsInitialized());
     // Extract address and amount from the request
     QList<std::pair<CScript, CAmount> > sendingTos = r.paymentRequest.getPayTo();
-    Q_FOREACH (const PAIRTYPE(CScript, CAmount)& sendingTo, sendingTos) {
+    //Q_FOREACH (const PAIRTYPE(CScript, CAmount)& sendingTo, sendingTos) {
+    for (const PAIRTYPE(CScript, CAmount)& sendingTo : sendingTos) {
         CTxDestination dest;
         if (ExtractDestination(sendingTo.first, dest))
             QCOMPARE(PaymentServer::verifyAmount(sendingTo.second), false);

--- a/src/qt/trafficgraphwidget.cpp
+++ b/src/qt/trafficgraphwidget.cpp
@@ -13,6 +13,8 @@
 
 #include <cmath>
 
+#include <QPainterPath>
+
 #define XMARGIN                 10
 #define YMARGIN                 10
 

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -269,14 +269,16 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, TransactionReco
     strHTML += "<b>" + tr("Transaction total size") + ":</b> " + QString::number(wtx.GetTotalSize()) + " bytes<br>";
 
     // Message from normal smartiecoin:URI (smartiecoin:XyZ...?message=example)
-    Q_FOREACH (const PAIRTYPE(std::string, std::string)& r, wtx.vOrderForm)
+    //Q_FOREACH (const PAIRTYPE(std::string, std::string)& r, wtx.vOrderForm)
+    for (const PAIRTYPE(std::string, std::string)& r : wtx.vOrderForm)
         if (r.first == "Message")
             strHTML += "<br><b>" + tr("Message") + ":</b><br>" + GUIUtil::HtmlEscape(r.second, true) + "<br>";
 
     //
     // PaymentRequest info:
     //
-    Q_FOREACH (const PAIRTYPE(std::string, std::string)& r, wtx.vOrderForm)
+    //Q_FOREACH (const PAIRTYPE(std::string, std::string)& r, wtx.vOrderForm)
+    for (const PAIRTYPE(std::string, std::string)& r : wtx.vOrderForm)
     {
         if (r.first == "PaymentRequest")
         {

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -28,6 +28,10 @@
 
 #include <boost/foreach.hpp>
 
+#include <boost/bind/bind.hpp>
+#include <boost/signals2/signal.hpp>
+using namespace boost::placeholders;
+
 // Amount column is right-aligned it contains numbers
 static int column_alignments[] = {
         Qt::AlignLeft|Qt::AlignVCenter, /* status */

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -35,6 +35,10 @@
 
 #include <boost/foreach.hpp>
 
+#include <boost/bind/bind.hpp>
+#include <boost/signals2/signal.hpp>
+using namespace boost::placeholders;
+
 WalletModel::WalletModel(const PlatformStyle *platformStyle, CWallet *wallet, OptionsModel *optionsModel, QObject *parent) :
     QObject(parent), wallet(wallet), optionsModel(optionsModel), addressTableModel(0),
     transactionTableModel(0),

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -5,6 +5,10 @@
 
 #include "validationinterface.h"
 
+#include <boost/bind/bind.hpp>
+#include <boost/signals2/signal.hpp>
+using namespace boost::placeholders;
+
 static CMainSignals g_signals;
 
 CMainSignals& GetMainSignals()


### PR DESCRIPTION
Here it is my build process with errors and fixes. Here v as alias of vim. I typed number of line where I pasted some lines.

```
wget https://github.com/SmartiesCoin/Smartiecoin/archive/refs/tags/1.11.tar.gz
tar xf 1.11.tar.gz
cd Smartiecoin-1.11
./autogen.sh 
./configure --with-incompatible-bdb
make
  validationinterface.cpp:16:110: error: ‘_1’ was not declared in this scope
     16 |     g_signals.AcceptedBlockHeader.connect(boost::bind(&CValidationInterface::AcceptedBlockHeader, pwalletIn, _1));
v src/validationinterface.cpp
  8:#include <boost/bind/bind.hpp>
  #include <boost/signals2/signal.hpp>
  using namespace boost::placeholders;
make
  qt/bitcoingui.cpp:1486:86: error: ‘_1’ was not declared in this scope
   1486 |     uiInterface.ThreadSafeMessageBox.connect(boost::bind(ThreadSafeMessageBox, this, _1, _2, _3));
v src/qt/bitcoingui.cpp
  67:#include <boost/bind/bind.hpp>
  #include <boost/signals2/signal.hpp>
  using namespace boost::placeholders;
make
  qt/clientmodel.cpp:379:70: error: ‘_1’ was not declared in this scope
    379 |     uiInterface.ShowProgress.connect(boost::bind(ShowProgress, this, _1, _2));
v src/qt/clientmodel.cpp
  32:#include <boost/bind/bind.hpp>
  #include <boost/signals2/signal.hpp>
  using namespace boost::placeholders;
make
  qt/splashscreen.cpp: In function ‘void ConnectWallet(SplashScreen*, CWallet*)’:
  qt/splashscreen.cpp:168:68: error: ‘_1’ was not declared in this scope
    168 |     wallet->ShowProgress.connect(boost::bind(ShowProgress, splash, _1, _2));
v src/qt/splashscreen.cpp
  26:#include <boost/bind/bind.hpp>
  #include <boost/signals2/signal.hpp>
  using namespace boost::placeholders;
v src/qt/trafficgraphwidget.cpp
  16:#include <QPainterPath>
v src/qt/transactiontablemodel.cpp
  31:#include <boost/bind/bind.hpp>
  #include <boost/signals2/signal.hpp>
  using namespace boost::placeholders;
v src/qt/walletmodel.cpp
  38:#include <boost/bind/bind.hpp>
  #include <boost/signals2/signal.hpp>
  using namespace boost::placeholders;
make
  qt/paymentserver.cpp:560:70: error: macro "Q_FOREACH_IMPL" passed 4 arguments, but takes just 3
    560 |     Q_FOREACH(const PAIRTYPE(CScript, CAmount)& sendingTo, sendingTos) {
  ...
  qt/paymentserver.cpp: In member function ‘bool PaymentServer::processPaymentRequest(const PaymentRequestPlus&, SendCoinsRecipient&)’:
  /usr/include/x86_64-linux-gnu/qt5/QtCore/qglobal.h:1133:5: error: ‘Q_FOREACH_IMPL’ was not declared in this scope
   1133 |     Q_FOREACH_IMPL(variable, Q_FOREACH_JOIN(_container_, __LINE__), container)
v src/qt/paymentserver.cpp
   560://Q_FOREACH(const PAIRTYPE(CScript, CAmount)& sendingTo, sendingTos) {
    for (const PAIRTYPE(CScript, CAmount)& sendingTo : sendingTos) {
make
  qt/transactiondesc.cpp:272:75: error: macro "Q_FOREACH_IMPL" passed 4 arguments, but takes just 3
    272 |     Q_FOREACH (const PAIRTYPE(std::string, std::string)& r, wtx.vOrderForm)
v src/qt/transactiondesc.cpp
  272://Q_FOREACH (const PAIRTYPE(std::string, std::string)& r, wtx.vOrderForm)
    for (const PAIRTYPE(std::string, std::string)& r : wtx.vOrderForm)
  280://Q_FOREACH (const PAIRTYPE(std::string, std::string)& r, wtx.vOrderForm)
    for (const PAIRTYPE(std::string, std::string)& r : wtx.vOrderForm)
make
  qt/test/paymentservertests.cpp:199:71: error: macro "Q_FOREACH_IMPL" passed 4 arguments, but takes just 3
    199 |     Q_FOREACH (const PAIRTYPE(CScript, CAmount)& sendingTo, sendingTos) {
v src/qt/test/paymentservertests.cpp
  199://Q_FOREACH (const PAIRTYPE(CScript, CAmount)& sendingTo, sendingTos) {
    for (const PAIRTYPE(CScript, CAmount)& sendingTo : sendingTos) {
make
  ..
  make[1]: Nothing to be done for 'all-am'.
  make[1]: Leaving directory '/mnt/blockchains/crypto/networks/smt/Smartiecoin-1.11'
ls -l src/qt/smartiecoin-qt 
  -rwxr-xr-x 1 y y 238982384 May 29 21:39 src/qt/smartiecoin-qt
```